### PR TITLE
[STEP-8] 주문/결제 시스템의 이벤트 기반 리팩토링 및 보고서 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,10 +83,12 @@ sourceSets["main"].java.srcDir(querydslSrcDir)
 tasks.withType<Test> {
     useJUnitPlatform()
     systemProperty("user.timezone", "UTC")
+    systemProperty("file.encoding", "UTF-8") // Warning:(55, 39) Non-ASCII characters
 }
 
 tasks.withType<JavaCompile> {
     options.generatedSourceOutputDirectory = file(querydslSrcDir)
+    options.encoding = "UTF-8" // Warning:(55, 39) Non-ASCII characters
 }
 
 tasks.named("clean") {

--- a/docs/report/event-driven-refactoring-report.md
+++ b/docs/report/event-driven-refactoring-report.md
@@ -1,0 +1,251 @@
+# 주문 및 결제 시스템의 이벤트 기반 리팩토링
+
+## 1. 문제 정의 (AS-IS)
+
+### 1.1 문제 상황
+
+현재 주문/결제 시스템은 하나의 트랜잭션 내에서 핵심 비즈니스 로직과 부가 기능을 모두 동기적으로 처리하고 있습니다.
+
+```java
+public class OrderPlaceProcessor {
+	@Transactional
+	public void execute(Command command) {
+		// 1. 재고 차감 (핵심)
+		// 2. 주문 상태 변경 (핵심)
+		// 3. 포인트 차감 (핵심)
+		// 4. 쿠폰 사용 (핵심)
+		// 5. 슬랙 알림 메시지 전송 (부가)
+		// 6. Redis 판매량 집계 (부가)
+	}
+}
+```
+
+### 1.2 구체적인 문제점
+
+#### 1.2.1 긴 트랜잭션으로 인한 동시성 저하
+
+하나의 트랜잭션 내에서 동시성 제어를 위해 잠금을 획득한 상태에서 너무 많은 작업을 수행합니다. 이로 인해 해당 자원에 접근하는 다른 요청들이 대기하거나 데드락 상황을 유발할 수 있습니다.
+
+#### 1.2.2 외부 시스템에 대한 의존성
+
+트랜잭션 범위 내에 데이터베이스와 무관한 외부 시스템(Slack, Redis)을 포함하고 있습니다. 외부 시스템의 네트워크 지연이나 예외 발생 시 전체 트랜잭션이 롤백되어 핵심 비즈니스까지 실패하게 됩니다.
+
+#### 1.2.3 느린 응답 시간
+
+클라이언트는 모든 작업(핵심 + 부가)이 완료될 때까지 대기해야 하므로, 불필요하게 긴 응답 시간이 발생합니다.
+
+### 1.3 AS-IS 처리 흐름
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Processor as OrderPlaceProcessor
+    participant DB
+    participant External as 외부 시스템<br/>(Slack, Redis)
+    Client ->> Processor: POST /orders
+    activate Processor
+    Note over Processor, External: @Transactional 시작 (잠금 획득)
+    Processor ->> DB: 1~4. 핵심 비즈니스<br/>(재고/주문/포인트/쿠폰)
+    activate DB
+    DB -->> Processor: 완료
+    deactivate DB
+    Processor ->> External: 5. 슬랙 알림 전송
+    activate External
+    Note over External: 네트워크 지연<br/>실패 시 롤백
+    External -->> Processor: 완료
+    deactivate External
+    Processor ->> External: 6. Redis 판매량 집계
+    activate External
+    Note over External: 외부 의존<br/>실패 시 롤백
+    External -->> Processor: 완료
+    deactivate External
+    Note over Processor, External: @Transactional 커밋 (잠금 해제)
+    Processor -->> Client: 200 OK (느린 응답)
+    deactivate Processor
+    Note over Client, External: 문제: 긴 트랜잭션, 외부 시스템 장애 시 롤백, 느린 응답
+```
+
+---
+
+## 2. 해결 방안 (TO-BE)
+
+### 2.1 핵심 개선 전략
+
+**핵심 비즈니스 로직과 부가 비즈니스 로직을 분리하여, 부가 로직을 이벤트 기반 아키텍처로 비동기 처리합니다.**
+
+- **핵심 비즈니스 로직**: 재고 차감, 주문 상태 변경, 포인트 차감, 쿠폰 사용
+- **부가 비즈니스 로직**: 슬랙 알림 전송, Redis 판매량 집계
+
+### 2.2 이벤트 기반 아키텍처 적용
+
+#### 2.2.1 이벤트 발행
+
+주문/결제가 완료되면 `OrderPlacedEvent`를 발행합니다.
+
+```java
+public class OrderPlaceWithEventProcessor implements OrderPlaceProcessor {
+
+	@Transactional
+	public Output execute(Command command) {
+		// 1. 핵심 비즈니스 로직 처리
+		// - 재고 차감
+		// - 주문 상태 변경
+		// - 포인트 차감
+		// - 쿠폰 사용
+
+		// 2. 이벤트 발행
+		eventPublisher.publishEvent(new OrderPlacedEvent(order.id()));
+
+		return output;
+	}
+}
+```
+
+#### 2.2.2 이벤트 리스너 구현
+
+트랜잭션 커밋 이후 비동기로 부가 로직을 처리하는 EventListener를 구현합니다.
+
+**슬랙 알림 리스너**
+
+```java
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderPlacedNotificationEventListener {
+	private final SlackSendMessageClient slackSendMessageClient;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(OrderPlacedEvent event) {
+		try {
+			log.debug("[OrderPlacedNotificationEventListener] Thread={}",
+				Thread.currentThread().getName());
+
+			String message = String.format(
+				"[주문 확정🎉] orderId=%s, 주문 확정 일시=%s",
+				event.orderId(),
+				event.occurredAt()
+			);
+
+			slackSendMessageClient.send(message);
+		} catch (Exception e) {
+			log.error("슬랙 메시지 전송 중 에러 발생", e);
+		}
+	}
+}
+```
+
+**판매량 집계 리스너**
+
+```java
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderPlacedProductRankingEventListener {
+	private final ProductRankingStore productRankingStore;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(OrderPlacedEvent event) {
+		try {
+			log.debug("[+OrderPlacedProductRankingEventListener] 진입: Thread={}", Thread.currentThread().getName());
+			LocalDateTime now = event.occurredAt();
+			LocalDate today = now.toLocalDate();
+
+			event.orderLines()
+				.forEach(
+					(orderLine) -> productRankingStore.increment(orderLine.productId(), orderLine.orderQuantity(),
+						today,
+						now));
+		} catch (Exception e) {
+			log.error("[알수 없는 에러 발생] 주문 확정 이후, 판매량을 증가시키는데 에러가 발생헀습니다.", e);
+		}
+	}
+
+}
+```
+
+### 2.3 TO-BE 처리 흐름
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Processor as OrderPlaceProcessor
+    participant DB
+    participant Listeners as EventListeners<br/>(Slack, Redis)
+    Client ->> Processor: POST /orders
+    activate Processor
+    Note over Processor, DB: @Transactional 시작 (잠금 획득)
+    Processor ->> DB: 1~4. 핵심 비즈니스<br/>(재고/주문/포인트/쿠폰)
+    activate DB
+    DB -->> Processor: 완료
+    deactivate DB
+    Processor ->> Processor: publishEvent(OrderPlacedEvent)
+    Note over Processor, DB: @Transactional 커밋 (잠금 해제)
+    Processor -->> Client: 200 OK (빠른 응답 ✅)
+    deactivate Processor
+    Note over Listeners: 트랜잭션 커밋 후<br/>@Async 비동기 실행
+    activate Listeners
+    Note over Listeners: 5. 슬랙 알림<br/>6. Redis 판매량 집계<br/>(실패해도 주문 영향 없음)
+    deactivate Listeners
+    Note over Client, Listeners: 개선: 짧은 트랜잭션, 장애 격리, 빠른 응답
+```
+
+---
+
+## 3. 개선 효과
+
+### 3.1 주요 개선 사항
+
+| 항목          | AS-IS                  | TO-BE             |
+|-------------|------------------------|-------------------|
+| **트랜잭션 범위** | 모든 작업 포함 (1~6)         | 핵심 비즈니스만 (1~4)    |
+| **잠금 시간**   | 외부 시스템 호출까지 포함         | 핵심 DB 작업만 포함      |
+| **응답 시간**   | 모든 작업 완료 후 응답          | 핵심 로직 완료 후 즉시 응답  |
+| **장애 영향**   | 외부 시스템 실패 시 전체 롤백      | 외부 시스템 실패 격리      |
+| **확장성**     | 새 기능 추가 시 Processor 수정 | EventListener만 추가 |
+| **테스트**     | 모든 의존성 필요              | 관심사별 독립 테스트 가능    |
+
+### 3.2 이벤트 기반 아키텍처의 장점
+
+#### 3.2.1 트랜잭션 최적화
+
+- 핵심 비즈니스 로직만 트랜잭션에 포함하여 잠금 시간 단축
+- 동시성 향상 및 데드락 위험 감소
+
+#### 3.2.2 장애 격리
+
+- 외부 시스템 장애가 핵심 비즈니스에 영향을 주지 않음
+- 각 EventListener가 독립적으로 예외 처리 가능
+
+#### 3.2.3 빠른 응답 시간
+
+- 클라이언트는 핵심 로직 완료 즉시 응답 받음
+- 부가 기능은 백그라운드에서 비동기 처리
+
+#### 3.2.4 높은 확장성
+
+- 새로운 후속 처리 추가 시 EventListener만 추가하면 됨
+- 기존 주문 로직 변경 불필요
+
+#### 3.2.5 테스트 용이성
+
+- 주문 로직과 부가 로직을 독립적으로 테스트 가능
+- 단위 테스트 작성이 더 간단해짐
+- 통합 테스트 작성은 비동기 -> 동기적 후처리로 변경 후 진행
+  ([OrderPlaceWithEventProcessorIntegrationTest.java](../../src/test/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessorIntegrationTest.java))
+
+---
+
+## 4. 결론
+
+이벤트 기반 아키텍처를 도입하여 핵심 비즈니스 로직과 부가 기능을 분리함으로써 아래와 같은 이점을 얻을 수 있었습니다.
+
+1. **성능 개선**: 트랜잭션 최적화로 동시성 향상 및 응답 시간 단축
+2. **안정성 향상**: 외부 시스템 장애로부터 핵심 비즈니스 보호
+3. **유지보수성 개선**: 관심사 분리로 코드 변경 영향 범위 최소화
+4. **확장성 확보**: 새로운 기능 추가 시 기존 코드 수정 불필요
+
+이를 통해 더 견고하고 확장 가능한 주문/결제 시스템을 구축할 수 있습니다.

--- a/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedNotificationEventListener.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedNotificationEventListener.java
@@ -30,7 +30,7 @@ public class OrderPlacedNotificationEventListener {
 				.append(" orderId=" + event.orderId())
 				.append(" 주문 확정 일시=" + event.occurredAt())
 				.toString();
-			
+
 			slackSendMessageClient.send(message);
 		} catch (Exception e) {
 			log.error("[알수 없는 에러 발생] 주문 확정 이후, 슬랙 메세지를 보내는데 에러가 발생했습니다.", e);

--- a/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedNotificationEventListener.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedNotificationEventListener.java
@@ -1,0 +1,40 @@
+package kr.hhplus.be.commerce.application.event;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.hhplus.be.commerce.application.order.OrderPlaceProcessor;
+import kr.hhplus.be.commerce.domain.order.event.OrderPlacedEvent;
+import kr.hhplus.be.commerce.infrastructure.client.slack.SlackSendMessageClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link OrderPlaceProcessor}의 후처리 로직입니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderPlacedNotificationEventListener {
+	private final SlackSendMessageClient slackSendMessageClient;
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(OrderPlacedEvent event) {
+		try {
+			log.debug("[+OrderPlacedNotificationEventListener] 진입: Thread={}", Thread.currentThread().getName());
+			final String message = new StringBuilder()
+				.append("[주문 확정🎉]")
+				.append(" orderId=" + event.orderId())
+				.append(" 주문 확정 일시=" + event.occurredAt())
+				.toString();
+			
+			slackSendMessageClient.send(message);
+		} catch (Exception e) {
+			log.error("[알수 없는 에러 발생] 주문 확정 이후, 슬랙 메세지를 보내는데 에러가 발생했습니다.", e);
+		}
+	}
+
+}

--- a/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedProductRankingEventListener.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedProductRankingEventListener.java
@@ -29,6 +29,7 @@ public class OrderPlacedProductRankingEventListener {
 	public void handle(OrderPlacedEvent event) {
 		try {
 			log.debug("[+OrderPlacedProductRankingEventListener] 진입: Thread={}", Thread.currentThread().getName());
+			
 			LocalDateTime now = event.occurredAt();
 			LocalDate today = now.toLocalDate();
 

--- a/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedProductRankingEventListener.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedProductRankingEventListener.java
@@ -1,0 +1,45 @@
+package kr.hhplus.be.commerce.application.event;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import kr.hhplus.be.commerce.application.order.OrderPlaceProcessor;
+import kr.hhplus.be.commerce.domain.order.event.OrderPlacedEvent;
+import kr.hhplus.be.commerce.domain.product_ranking.store.ProductRankingStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderPlacedProductRankingEventListener {
+	private final ProductRankingStore productRankingStore;
+
+	/**
+	 * {@link OrderPlaceProcessor}의 후처리 로직입니다.
+	 */
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handle(OrderPlacedEvent event) {
+		try {
+			log.debug("[+OrderPlacedProductRankingEventListener] 진입: Thread={}", Thread.currentThread().getName());
+			LocalDateTime now = event.occurredAt();
+			LocalDate today = now.toLocalDate();
+
+			event.orderLines()
+				.forEach(
+					(orderLine) -> productRankingStore.increment(orderLine.productId(), orderLine.orderQuantity(),
+						today,
+						now));
+		} catch (Exception e) {
+			log.error("[알수 없는 에러 발생] 주문 확정 이후, 판매량을 증가시키는데 에러가 발생헀습니다.", e);
+		}
+	}
+
+}

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
@@ -197,7 +197,7 @@ public class OrderPlaceWithDatabaseLockProcessor implements OrderPlaceProcessor 
 		Payment payment = Payment.fromOrder(command.userId(), order.id(),
 				command.paymentAmount())
 			.succeed(now);
-		
+
 		return new Output(
 			saveCashWithHistory(command, usedCash, originalBalance),
 			userCouponRepository.save(userCoupon),
@@ -237,6 +237,7 @@ public class OrderPlaceWithDatabaseLockProcessor implements OrderPlaceProcessor 
 		return OrderPlaceInput.builder()
 			.idempotencyKey(idempotencyKey)
 			.userId(command.userId())
+			.now(timeProvider.now())
 			.orderLineInputs(command.orderLineCommands()
 				.stream()
 				.map(orderLineCommand -> {

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
@@ -197,11 +197,9 @@ public class OrderPlaceWithDatabaseLockProcessor implements OrderPlaceProcessor 
 		Payment payment = Payment.fromOrder(command.userId(), order.id(),
 				command.paymentAmount())
 			.succeed(now);
-
-		saveCashWithHistory(command, usedCash, originalBalance);
-
+		
 		return new Output(
-			cashRepository.save(cash),
+			saveCashWithHistory(command, usedCash, originalBalance),
 			userCouponRepository.save(userCoupon),
 			productRepository.saveAll(products),
 			paymentRepository.save(payment),

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDatabaseLockProcessor.java
@@ -88,7 +88,7 @@ public class OrderPlaceWithDatabaseLockProcessor implements OrderPlaceProcessor 
 		// 주문 및 잔액을 차감합니다.
 		// 주문 식별자를 미리 받기 위해서 save method를 호출합니다.
 		Order order = orderRepository.save(Order.ofPending(command.userId()))
-			.place(toOrderPlaceInput(command, productsWithDecreasedStock, command.idempotencyKey()));
+			.place(toOrderPlaceInput(command, productsWithDecreasedStock, command.idempotencyKey())).order();
 
 		messageRepository.save(Message.ofPending(
 			order.id(),

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDistributedLockProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDistributedLockProcessor.java
@@ -176,7 +176,7 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 
 		Payment payment = Payment.fromOrder(command.userId(), order.id(), command.paymentAmount())
 			.succeed(now);
-		
+
 		return new Output(
 			saveCashWithHistory(command, usedCash, originalBalance),
 			null,
@@ -240,6 +240,7 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 		return OrderPlaceInput.builder()
 			.idempotencyKey(idempotencyKey)
 			.userId(command.userId())
+			.now(timeProvider.now())
 			.orderLineInputs(command.orderLineCommands()
 				.stream()
 				.map(orderLineCommand -> {

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDistributedLockProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithDistributedLockProcessor.java
@@ -8,8 +8,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
@@ -83,13 +83,13 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 		command.validate();
 		LocalDateTime now = timeProvider.now();
 		LocalDate today = timeProvider.today();
-		userRepository.findByIdForUpdate(command.userId())
-			.orElseThrow(() -> new CommerceException(CommerceCode.NOT_FOUND_USER));
 
-		Optional<Order> alreadyPlacedOrderOpt = orderRepository.findByIdempotencyKey(command.idempotencyKey());
-		if (alreadyPlacedOrderOpt.isPresent()) {
+		if (isAlreadyPlacedOrder(command.idempotencyKey())) {
 			return Output.empty();
 		}
+
+		userRepository.findById(command.userId())
+			.orElseThrow(() -> new CommerceException(CommerceCode.NOT_FOUND_USER));
 
 		// 상품의 비관적 잠금을 획득한 상태로 조회 및 재고를 감소시킵니다.
 		List<Product> productsWithDecreasedStock = decreaseStock(command, fetchProductsForUpdate(command));
@@ -99,8 +99,15 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 
 		// 주문 및 잔액을 차감합니다.
 		// 주문 식별자를 미리 받기 위해서 save method를 호출합니다.
-		Order order = orderRepository.save(Order.ofPending(command.userId()))
-			.place(toOrderPlaceInput(command, productsWithDecreasedStock, command.idempotencyKey())).order();
+		Order order;
+		try {
+			order = orderRepository.save(Order.ofPending(command.userId()));
+		} catch (DataIntegrityViolationException e) {
+			log.warn("중복 결제 건이 있어서 반환합니다. idempotencyKey={}", command.idempotencyKey());
+			return Output.empty();
+		}
+		Order placedOrder = order.place(
+			buildOrderPlaceInput(command, productsWithDecreasedStock, command.idempotencyKey())).order();
 
 		messageRepository.save(Message.ofPending(
 			order.id(),
@@ -108,9 +115,15 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 			OrderConfirmedMessagePayload.from(order.id(), today, now)
 		));
 
+		return processPayment(command, placedOrder, cash, productsWithDecreasedStock, now);
+	}
+
+	private Output processPayment(Command command, Order placedOrder, Cash cash,
+		List<Product> productsWithDecreasedStock,
+		LocalDateTime now) {
 		return isNull(command.userCouponId()) ?
-			executeWithoutCoupon(command, order, cash, productsWithDecreasedStock, now) :
-			executeWithCoupon(command, order, cash, productsWithDecreasedStock, now);
+			processPaymentWithoutCoupon(command, placedOrder, cash, productsWithDecreasedStock, now) :
+			processPaymentWithCoupon(command, placedOrder, cash, productsWithDecreasedStock, now);
 	}
 
 	@Recover
@@ -124,6 +137,10 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 			throw new CommerceException(CommerceCode.EXCEEDED_RETRY_COUNT_FOR_LOCK);
 		}
 		throw e;
+	}
+
+	private boolean isAlreadyPlacedOrder(String idempotencyKey) {
+		return orderRepository.findByIdempotencyKey(idempotencyKey).isPresent();
 	}
 
 	private List<Product> fetchProductsForUpdate(Command command) {
@@ -150,7 +167,7 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 			.toList();
 	}
 
-	private Output executeWithoutCoupon(Command command, Order order, Cash cash, List<Product> products,
+	private Output processPaymentWithoutCoupon(Command command, Order order, Cash cash, List<Product> products,
 		LocalDateTime now) {
 		validatePaymentAmountIsMatched(command.paymentAmount(), order);
 
@@ -159,12 +176,9 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 
 		Payment payment = Payment.fromOrder(command.userId(), order.id(), command.paymentAmount())
 			.succeed(now);
-
-		cashHistoryRepository.save(
-			CashHistory.recordOfPurchase(command.userId(), usedCash.balance(), originalBalance));
-
+		
 		return new Output(
-			cashRepository.save(usedCash),
+			saveCashWithHistory(command, usedCash, originalBalance),
 			null,
 			productRepository.saveAll(products),
 			paymentRepository.save(payment),
@@ -172,7 +186,7 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 		);
 	}
 
-	private Output executeWithCoupon(Command command, Order order, Cash cash, List<Product> products,
+	private Output processPaymentWithCoupon(Command command, Order order, Cash cash, List<Product> products,
 		LocalDateTime now) {
 		UserCoupon userCoupon = userCouponRepository.findById(command.userCouponId())
 			.orElseThrow(() -> new CommerceException(CommerceCode.NOT_FOUND_USER_COUPON));
@@ -187,16 +201,20 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 				command.paymentAmount())
 			.succeed(now);
 
-		cashHistoryRepository.save(
-			CashHistory.recordOfPurchase(command.userId(), usedCash.balance(), originalBalance));
-
 		return new Output(
-			cashRepository.save(cash),
+			saveCashWithHistory(command, usedCash, originalBalance),
 			userCouponRepository.save(userCoupon),
 			productRepository.saveAll(products),
 			paymentRepository.save(payment),
 			orderRepository.save(order)
 		);
+	}
+
+	private Cash saveCashWithHistory(Command command, Cash cash, BigDecimal originalBalance) {
+		cashHistoryRepository.save(
+			CashHistory.recordOfPurchase(command.userId(), cash.balance(), originalBalance));
+
+		return cashRepository.save(cash);
 	}
 
 	private void validatePaymentAmountIsMatched(BigDecimal paymentAmount, UserCoupon userCoupon,
@@ -214,7 +232,7 @@ public class OrderPlaceWithDistributedLockProcessor implements OrderPlaceProcess
 		}
 	}
 
-	private OrderPlaceInput toOrderPlaceInput(Command command, List<Product> products, String idempotencyKey) {
+	private OrderPlaceInput buildOrderPlaceInput(Command command, List<Product> products, String idempotencyKey) {
 		Map<Long, Product> productIdToProductMap = products
 			.stream()
 			.collect(toMap(Product::id, product -> product));

--- a/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessor.java
+++ b/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessor.java
@@ -230,6 +230,7 @@ public class OrderPlaceWithEventProcessor implements OrderPlaceProcessor {
 		return OrderPlaceInput.builder()
 			.idempotencyKey(idempotencyKey)
 			.userId(command.userId())
+			.now(timeProvider.now())
 			.orderLineInputs(command.orderLineCommands()
 				.stream()
 				.map(orderLineCommand -> {

--- a/src/main/java/kr/hhplus/be/commerce/domain/event/Event.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/event/Event.java
@@ -1,0 +1,7 @@
+package kr.hhplus.be.commerce.domain.event;
+
+import java.time.LocalDateTime;
+
+public interface Event {
+	LocalDateTime occurredAt();
+}

--- a/src/main/java/kr/hhplus/be/commerce/domain/event/EventPublisher.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/event/EventPublisher.java
@@ -1,0 +1,9 @@
+package kr.hhplus.be.commerce.domain.event;
+
+import java.util.Collection;
+
+public interface EventPublisher {
+	void publish(Collection<? extends Event> events);
+
+	void publish(Event event);
+}

--- a/src/main/java/kr/hhplus/be/commerce/domain/order/event/OrderPlacedEvent.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/order/event/OrderPlacedEvent.java
@@ -1,0 +1,34 @@
+package kr.hhplus.be.commerce.domain.order.event;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import kr.hhplus.be.commerce.domain.event.Event;
+import kr.hhplus.be.commerce.domain.order.model.Order;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record OrderPlacedEvent(
+	LocalDateTime occurredAt,
+	Long orderId,
+	List<OrderLineSummary> orderLines
+) implements Event {
+	public static Event of(Order order) {
+		return OrderPlacedEvent
+			.builder()
+			.occurredAt(LocalDateTime.now())
+			.orderId(order.id())
+			.orderLines(order.orderLines().stream()
+				.map((orderLine) -> new OrderLineSummary(orderLine.productId(), orderLine.orderQuantity()))
+				.toList()
+			)
+			.build();
+	}
+
+	public record OrderLineSummary(
+		Long productId,
+		Integer orderQuantity
+	) {
+	}
+}

--- a/src/main/java/kr/hhplus/be/commerce/domain/order/event/OrderPlacedEvent.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/order/event/OrderPlacedEvent.java
@@ -14,10 +14,9 @@ public record OrderPlacedEvent(
 	Long orderId,
 	List<OrderLineSummary> orderLines
 ) implements Event {
-	public static Event of(Order order) {
-		return OrderPlacedEvent
-			.builder()
-			.occurredAt(LocalDateTime.now())
+	public static Event of(Order order, LocalDateTime occurredAt) {
+		return OrderPlacedEvent.builder()
+			.occurredAt(occurredAt)
 			.orderId(order.id())
 			.orderLines(order.orderLines().stream()
 				.map((orderLine) -> new OrderLineSummary(orderLine.productId(), orderLine.orderQuantity()))

--- a/src/main/java/kr/hhplus/be/commerce/domain/order/model/Order.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/order/model/Order.java
@@ -68,7 +68,7 @@ public record Order(
 			.idempotencyKey(input.idempotencyKey())
 			.build();
 
-		return new PlaceResult(order, List.of(OrderPlacedEvent.of(order)));
+		return new PlaceResult(order, List.of(OrderPlacedEvent.of(order, input.now())));
 	}
 
 	@InfrastructureOnly

--- a/src/main/java/kr/hhplus/be/commerce/domain/order/model/Order.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/order/model/Order.java
@@ -6,7 +6,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import kr.hhplus.be.commerce.domain.event.Event;
 import kr.hhplus.be.commerce.domain.global.annotation.InfrastructureOnly;
+import kr.hhplus.be.commerce.domain.order.event.OrderPlacedEvent;
 import kr.hhplus.be.commerce.domain.order.model.enums.OrderStatus;
 import kr.hhplus.be.commerce.domain.order.model.input.OrderPlaceInput;
 import lombok.AccessLevel;
@@ -40,7 +42,7 @@ public record Order(
 			.build();
 	}
 
-	public Order place(OrderPlaceInput input) {
+	public PlaceResult place(OrderPlaceInput input) {
 		List<OrderLine> orderLines = input.orderLineInputs()
 			.stream()
 			.map((orderLineInput) -> OrderLine.place(orderLineInput.productId(), orderLineInput.productName(),
@@ -54,7 +56,7 @@ public record Order(
 		BigDecimal discountAmount = nonNull(input.discountAmountCalculable()) ?
 			input.discountAmountCalculable().calculateDiscountAmount(amount) : BigDecimal.valueOf(0, 2);
 
-		return Order.builder()
+		Order order = Order.builder()
 			.id(id)
 			.userId(input.userId())
 			.status(OrderStatus.CONFIRMED)
@@ -65,6 +67,8 @@ public record Order(
 			.confirmedAt(input.now())
 			.idempotencyKey(input.idempotencyKey())
 			.build();
+
+		return new PlaceResult(order, List.of(OrderPlacedEvent.of(order)));
 	}
 
 	@InfrastructureOnly
@@ -84,4 +88,10 @@ public record Order(
 			.build();
 	}
 
+	public record PlaceResult(
+		Order order,
+		List<Event> events
+	) {
+
+	}
 }

--- a/src/main/java/kr/hhplus/be/commerce/domain/user/repository/UserRepository.java
+++ b/src/main/java/kr/hhplus/be/commerce/domain/user/repository/UserRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 import kr.hhplus.be.commerce.domain.user.model.User;
 
 public interface UserRepository {
-	Optional<User> findByIdForUpdate(Long id);
+	Optional<User> findById(Long id);
 }

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/client/slack/SlackSendMessageClientImpl.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/client/slack/SlackSendMessageClientImpl.java
@@ -2,10 +2,14 @@ package kr.hhplus.be.commerce.infrastructure.client.slack;
 
 import org.springframework.stereotype.Component;
 
+import lombok.extern.slf4j.Slf4j;
+
 @Component
+@Slf4j
 public class SlackSendMessageClientImpl implements SlackSendMessageClient {
 	@Override
 	public void send(String message) {
 		// TODO Impl.
+		log.info("[슬랙 메세지 발송 성공: {}", message);
 	}
 }

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/client/slack/SlackSendMessageClientImpl.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/client/slack/SlackSendMessageClientImpl.java
@@ -10,6 +10,6 @@ public class SlackSendMessageClientImpl implements SlackSendMessageClient {
 	@Override
 	public void send(String message) {
 		// TODO Impl.
-		log.info("[슬랙 메세지 발송 성공: {}", message);
+		log.info("[슬랙 메시지 발송 성공]: {}", message);
 	}
 }

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/config/order/OrderConfig.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/config/order/OrderConfig.java
@@ -53,8 +53,8 @@ public class OrderConfig {
 			userCouponRepository,
 			cashRepository,
 			cashHistoryRepository,
-			userRepository,
 			springEventPublisher,
+			userRepository,
 			timeProvider
 		);
 	}

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/config/order/OrderConfig.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/config/order/OrderConfig.java
@@ -5,15 +5,15 @@ import org.springframework.context.annotation.Configuration;
 
 import jakarta.persistence.EntityManager;
 import kr.hhplus.be.commerce.application.order.OrderPlaceProcessor;
-import kr.hhplus.be.commerce.application.order.OrderPlaceWithDistributedLockProcessor;
+import kr.hhplus.be.commerce.application.order.OrderPlaceWithEventProcessor;
 import kr.hhplus.be.commerce.domain.cash.repository.CashHistoryRepository;
 import kr.hhplus.be.commerce.domain.cash.repository.CashRepository;
 import kr.hhplus.be.commerce.domain.coupon.repository.UserCouponRepository;
-import kr.hhplus.be.commerce.domain.message.repository.MessageRepository;
 import kr.hhplus.be.commerce.domain.order.repository.OrderRepository;
 import kr.hhplus.be.commerce.domain.payment.repository.PaymentRepository;
 import kr.hhplus.be.commerce.domain.product.repository.ProductRepository;
 import kr.hhplus.be.commerce.domain.user.repository.UserRepository;
+import kr.hhplus.be.commerce.infrastructure.event.SpringEventPublisher;
 import kr.hhplus.be.commerce.infrastructure.persistence.order.OrderJpaRepository;
 import kr.hhplus.be.commerce.infrastructure.persistence.order.OrderLineJpaRepository;
 import kr.hhplus.be.commerce.infrastructure.persistence.order.OrderRepositoryImpl;
@@ -41,18 +41,18 @@ public class OrderConfig {
 		UserCouponRepository userCouponRepository,
 		CashRepository cashRepository,
 		CashHistoryRepository cashHistoryRepository,
-		MessageRepository messageRepository,
-		UserRepository userRepository
+		UserRepository userRepository,
+		SpringEventPublisher springEventPublisher
 	) {
-		return new OrderPlaceWithDistributedLockProcessor(
+		return new OrderPlaceWithEventProcessor(
 			orderRepository,
 			paymentRepository,
 			productRepository,
 			userCouponRepository,
 			cashRepository,
 			cashHistoryRepository,
-			messageRepository,
-			userRepository
+			userRepository,
+			springEventPublisher
 		);
 	}
 

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/event/SpringEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/event/SpringEventPublisher.java
@@ -1,0 +1,26 @@
+package kr.hhplus.be.commerce.infrastructure.event;
+
+import java.util.Collection;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import kr.hhplus.be.commerce.domain.event.Event;
+import kr.hhplus.be.commerce.domain.event.EventPublisher;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class SpringEventPublisher implements EventPublisher {
+	@Override
+	public void publish(Collection<? extends Event> events) {
+		events.forEach(applicationEventPublisher::publishEvent);
+	}
+
+	private final ApplicationEventPublisher applicationEventPublisher;
+	
+	@Override
+	public void publish(Event event) {
+		applicationEventPublisher.publishEvent(event);
+	}
+}

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/persistence/user/UserJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/persistence/user/UserJpaRepository.java
@@ -1,18 +1,9 @@
 package kr.hhplus.be.commerce.infrastructure.persistence.user;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import jakarta.persistence.LockModeType;
 import kr.hhplus.be.commerce.infrastructure.persistence.user.entity.UserEntity;
 
 public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
-	@Lock(LockModeType.PESSIMISTIC_WRITE)
-	@Query("SELECT u FROM UserEntity u WHERE u.id = :id")
-	Optional<UserEntity> findByIdForUpdate(@Param("id") Long id);
 
 }

--- a/src/main/java/kr/hhplus/be/commerce/infrastructure/persistence/user/UserRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/commerce/infrastructure/persistence/user/UserRepositoryImpl.java
@@ -12,8 +12,8 @@ public class UserRepositoryImpl implements UserRepository {
 	private final UserJpaRepository userJpaRepository;
 
 	@Override
-	public Optional<User> findByIdForUpdate(Long id) {
-		return userJpaRepository.findByIdForUpdate(id)
+	public Optional<User> findById(Long id) {
+		return userJpaRepository.findById(id)
 			.map(UserEntity::toDomain);
 	}
 }

--- a/src/test/java/kr/hhplus/be/commerce/infrastructure/config/TestAsyncConfig.java
+++ b/src/test/java/kr/hhplus/be/commerce/infrastructure/config/TestAsyncConfig.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.commerce.infrastructure.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.core.task.SyncTaskExecutor;
+
+@TestConfiguration
+public class TestAsyncConfig {
+
+	/**
+	 * ApplicationPublisher로 발행된 이벤트 처리를 테스트 환경에서 검증하고자 작성했습니다.
+	 * 테스트 환경에서는 발행된 이벤트들이 동기적으로 처리됩니다.
+	 */
+	@Bean
+	@Primary
+	public Executor asyncExecutor() {
+		return new SyncTaskExecutor();
+	}
+}


### PR DESCRIPTION
안녕하세요 튜터님, 오늘도 소중한 피드백 감사드립니다🙇‍♂️

## PR 설명
### 1. 보고서 작성
- [주문 및 결제 시스템의 이벤트 기반 리팩토링](https://github.com/jongwanra/commerce/blob/jongwanra/eda/docs/report/event-driven-refactoring-report.md)

### 2. 주문 및 결제 시스템의 이벤트 기반 리팩토링
#### 2-1. 주문/결제 프로세서
- [OrderPlaceWithEventProcessor](https://github.com/jongwanra/commerce/blob/jongwanra/eda/src/main/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessor.java)
  
#### 2-2. 주문/결제 시 상품 판매량 집계(이벤트 기반 비동기 후처리)
- [OrderPlacedProductRankingEventListener](https://github.com/jongwanra/commerce/blob/jongwanra/eda/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedProductRankingEventListener.java)

#### 2-3. 주문/결제 시 외부 플랫폼(Slack) 전송(이벤트 기반 비동기 후처리)
- [OrderPlacedNotificationEventListener](https://github.com/jongwanra/commerce/blob/jongwanra/eda/src/main/java/kr/hhplus/be/commerce/application/event/OrderPlacedNotificationEventListener.java)

#### 2-4. 테스트 코드 작성
- [OrderPlaceWithEventProcessorIntegrationTest](https://github.com/jongwanra/commerce/blob/jongwanra/eda/src/test/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessorIntegrationTest.java)

## 리뷰 포인트

### 1. 주문/결제 시 이벤트 기반 후처리 로직의 통합 테스트 방식에 대한 피드백 부탁드립니다.
#### 테스트 코드

- [OrderPlaceWithEventProcessorIntegrationTest](https://github.com/jongwanra/commerce/blob/jongwanra/eda/src/test/java/kr/hhplus/be/commerce/application/order/OrderPlaceWithEventProcessorIntegrationTest.java)

#### 현재 구현 방식

- 운영 환경: `@Async` + `@TransactionalEventListener`로 비동기 처리
- 테스트 환경: `TestAsyncConfig`를 통해 동기적으로 전환

#### 이렇게 구현한 이유
1. 테스트 실행 시간 단축: `Awaitility`로 비동기 완료를 대기하는 방식은 테스트 시간이 길어지고, 빌드 시간도 증가할 것으로 판단했습니다.
2. 테스트 안정성: 타임아웃이나 타이밍 이슈 없이 확실한 검증이 가능합니다.

#### 궁금한 부분
- 테스트 환경에서 비동기를 동기로 전환하는 방식이 일반적으로 적절한 접근인지 궁금합니다!


### 2. 이벤트 기반 후처리에서 최종적 일관성이 반드시 보장이 되어야 하는 경우에 대한 피드백 부탁드립니다.

#### 배경 

현업에서 이벤트 기반 후처리를 사용하고 있는데, 최종적 일관성 보장 방식에 대해 고민이 생겨 질문드립니다🤔


#### 현재 구현 방식 (예시: 리뷰 등록)

```text
1. 사용자가 리뷰를 등록한다.(데이터베이스 저장)
2. 이벤트를 발행한다 -> Elasticsearch 동기화 (이벤트 비동기 후처리) 
3. Elasticsearch 등록 실패 시 Message 테이블에 실패 기록을 저장한다.
4. 스케줄러가 주기적으로 Message 테이블 조회 -> 재시도 한다(최대 3회)
```

#### 고민되는 부분 

현재 방식은 이벤트 리스너 내에서 실패 시 Message를 저장하는데, 이 경우 아래와 같은 문제가 있습니다.

- 리뷰 저장 트랜잭션과 Message 저장 트랜잭션이 분리되어 있음
- Message 저장도 실패하면 MySQL과 Elasticsearch가 영구적으로 불일치 상태가 될 수 있음
- 최종적 일관성(Eventual Consistency)이 보장되지 않음

#### 대안: Transactional Outbox Pattern

- 리뷰와 Outbox 메시지가 같은 트랜잭션에서 원자적으로 저장됨
- Outbox 메시지가 있는 한 언젠가는 Elasticsearch에 반영됨이 보장됨
- 최종적 일관성을 확실하게 보장할 수 있음

#### 궁금한 부분

1. MySQL과 Elasticsearch 간의 데이터 동기화처럼 최종적 일관성이 중요한 경우, Transactional Outbox Pattern이 필수적인가요?
2. 아니면 현재처럼 "실패 시 Message 저장" 방식으로도 실무에서 충분히 사용 가능한가요?
3. 이런 케이스를 경험해보신 적이 있으시다면, 어떤 방식으로 해결하셨는지 궁금합니다.

